### PR TITLE
Doc fix

### DIFF
--- a/ansible/templates/centos7/daemon.sh.j2
+++ b/ansible/templates/centos7/daemon.sh.j2
@@ -7,6 +7,7 @@ set -e -u -x
 {% endif %}
 
 {% if doc %}
+Create a file omero-web-systemd.service. See example file below.
 cp omero-web-systemd.service /etc/systemd/system/omero-web.service
 {% else %}
 cp `dirname $0`/omero-web-systemd.service /etc/systemd/system/omero-web.service

--- a/ansible/templates/common/install.sh.j2
+++ b/ansible/templates/common/install.sh.j2
@@ -10,16 +10,17 @@ OMEROVER=${OMEROVER:-{{ omero_version }}}
 {% endif %}
 
 {% if doc %}
-curl -o OMERO.py.zip https://downloads.openmicroscopy.org/latest/omero5.3/py.zip
+cd {{ omero_user_home_dir }}
+wget https://downloads.openmicroscopy.org/latest/omero5.3/py.zip -O OMERO.py.zip
+unzip -q OMERO.py*
 {% else %}
 {{ virtualenv_path }}/bin/omego download --ice "{{ ice_version }}" --branch "${OMEROVER}" py
 {% endif %}
 
 zip=$(ls OMERO.py*.zip)
-zipname=${zip%.zip}
 rm -f $zip
 {% if doc %}
-mv $(find . -name 'OMERO.py*' -type d) {{ omero_user_home_dir }}/OMERO.py
+ln -s OMERO.py-* OMERO.py
 {% else %}
 if [ ! -d "{{ omero_user_home_dir }}/OMERO.py" ]; then
     mv $(find . -name 'OMERO.py*' -type d) {{ omero_user_home_dir }}/OMERO.py

--- a/ansible/templates/common/install.sh.j2
+++ b/ansible/templates/common/install.sh.j2
@@ -11,7 +11,7 @@ OMEROVER=${OMEROVER:-{{ omero_version }}}
 
 {% if doc %}
 cd {{ omero_user_home_dir }}
-wget https://downloads.openmicroscopy.org/latest/omero5.3/py.zip -O OMERO.py.zip
+curl -o OMERO.py.zip -L https://downloads.openmicroscopy.org/latest/omero5.3/py.zip
 unzip -q OMERO.py*
 {% else %}
 {{ virtualenv_path }}/bin/omego download --ice "{{ ice_version }}" --branch "${OMEROVER}" py

--- a/ansible/templates/omeroweb-install-doc.txt.j2
+++ b/ansible/templates/omeroweb-install-doc.txt.j2
@@ -66,3 +66,9 @@
 {% macro style() %}{% include path ignore missing with context %}{% endmacro %}
 {{ style()|indent }}
 {% endif %}
+
+{% if os == 'ubuntu' or os == 'osx' %}
+{% set path = os + '/run.sh.j2'%}
+{% macro style() %}{% include path ignore missing with context %}{% endmacro %}
+{{ style()|indent }}
+{% endif %}

--- a/ansible/templates/ubuntu/daemon.sh.j2
+++ b/ansible/templates/ubuntu/daemon.sh.j2
@@ -7,7 +7,8 @@ set -e -u -x
 {% endif %}
 
 {% if doc %}
-cp {{ os }}/omero-web-init.d /etc/init.d/omero-web
+Create a file omero-web-init.d. See example file below.
+cp omero-web-init.d /etc/init.d/omero-web
 {% else %}
 cp `dirname $0`/omero-web-init.d /etc/init.d/omero-web
 {% endif %}
@@ -16,9 +17,7 @@ chmod a+x /etc/init.d/omero-web
 update-rc.d -f omero-web remove
 update-rc.d -f omero-web defaults 98 02
 
-{% if doc %}
-{{ os }}/run
-{% else %}
+{% if not doc %}
 if [ ! "${container:-}" = docker ]; then
     `dirname $0`/run
 fi

--- a/ansible/templates/ubuntu/omero-web-init.d.j2
+++ b/ansible/templates/ubuntu/omero-web-init.d.j2
@@ -1,5 +1,5 @@
 {% if doc %}
-omero-web-init.d example::
+**omero-web-init.d** example::
 
 {% endif %}
 #!/bin/bash

--- a/ansible/templates/ubuntu/run.sh.j2
+++ b/ansible/templates/ubuntu/run.sh.j2
@@ -16,4 +16,6 @@ service redis start
 cron
 service nginx start
 service omero-web start
+{% if not doc %}
 exec bash
+{% endif %}

--- a/ansible/templates/ubuntu/run.sh.j2
+++ b/ansible/templates/ubuntu/run.sh.j2
@@ -10,7 +10,9 @@ set -e -u -x
 service redis start
 {% endif %}
 
+{% if not doc %}
 #service crond start # Doesn't work in Docker
+{% endif %}
 cron
 service nginx start
 service omero-web start

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible
+ansible==2.2.1.0


### PR DESCRIPTION
Adjust the documentation following forum post
see https://trello.com/c/KxFhIzXj/59-web-install-doc-generation

Instead of copying an example of the ``omero-web-init.d`` in the doc, we could
generate one by running the installation playbook and copy the file across.
If we opt for that option, this will require some adjustments to the autogen script in https://github.com/openmicroscopy/ome-documentation
cc @hflynn @aleksandra-tarkowska 

can be tested locally
``
ansible-playbook ./ansible/omeroweb-install-doc.yml -i ./ansible/hosts/ubuntu-ice3.6
``

This PR also caps ``ansible`` to ``2.2.1.0``, travis failure with ``2.2.2.0``