### PR TITLE
Doc fix

### DIFF
--- a/ansible/templates/common/omeroweb_configure.sh.j2
+++ b/ansible/templates/common/omeroweb_configure.sh.j2
@@ -17,7 +17,9 @@ set +u
 source {{ virtualenv_path }}/bin/activate
 set -u
 {% endif %}
-
+{% if doc %}
+# By default no value is set for WEBPREFIX but for example it can be set to /omero
+{% endif %}
 if [[ $WEBPREFIX = *[!\ ]* ]]; then
     {{ omero_user_home_dir }}/OMERO.py/bin/omero config set omero.web.prefix "{{ web_prefix or '${WEBPREFIX}' }}"
     {{ omero_user_home_dir }}/OMERO.py/bin/omero config set omero.web.static_url "{{ web_prefix or '${WEBPREFIX}' }}/static/"

--- a/ansible/templates/common/virtualenv2.sh.j2
+++ b/ansible/templates/common/virtualenv2.sh.j2
@@ -1,5 +1,5 @@
 {% if doc %}
-Install VirtualEnv (run as root)::
+Install in the virtualenv created previously (run as root)::
 {% else %}
 #!/bin/bash
 


### PR DESCRIPTION
 * Fix wording of section installing web requirements in virtual env
 * Give an example of webprefix, doc only

See  https://trello.com/c/iF5W5P64/95-2x-install-virtualenv-headings

cc @hflynn @kennethgillen 
When the page is generated, we will have

```
    OMERO_USER=omero
    WEBPORT=80
    WEBSERVER_NAME=localhost
    WEBPREFIX=/omero
```
and

```
Install in the virtualenv created previously (run as root)::
    
    /home/omero/omerowebvenv/bin/pip install --upgrade -r /home/omero/OMERO.py/share/web/requirements-py27.txt

```
