### PR TITLE
Check curl status

### DIFF
--- a/test/test_ansible.sh
+++ b/test/test_ansible.sh
@@ -50,9 +50,9 @@ docker logs ${IMAGE}
 
 #test 
 if [[ "darwin" == "${OSTYPE//[0-9.]/}" ]]; then
-    curl -I http://${DOCKER_IP}:8888${WEBPREFIX}/webclient/login/
+    curl -f -I http://${DOCKER_IP}:8888${WEBPREFIX}/webclient/login/
 else
-    curl -I http://${DOCKER_IP}:${WEBPORT}${WEBPREFIX}/webclient/login/
+    curl -f -I http://${DOCKER_IP}:${WEBPORT}${WEBPREFIX}/webclient/login/
 fi
 
 

--- a/test/test_services.sh
+++ b/test/test_services.sh
@@ -25,10 +25,10 @@ docker inspect -f {{.State.Running}} $CNAME
 
 # Log in to OMERO.web
 if [[ "darwin" == "${OSTYPE//[0-9.]/}" ]]; then
-  curl -I http://localhost:8888${WEBPREFIX}/webclient/login/
+  curl -f -I http://localhost:8888${WEBPREFIX}/webclient/login/
 else
   DOCKER_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' $CNAME)
-  curl -I http://${DOCKER_IP}:${WEBPORT}${WEBPREFIX}/webclient/login/
+  curl -f -I http://${DOCKER_IP}:${WEBPORT}${WEBPREFIX}/webclient/login/
 fi
 
 docker logs $CNAME

--- a/test/test_web.sh
+++ b/test/test_web.sh
@@ -12,6 +12,6 @@ bash $path/../${OS}-ice${ICEVER}/run
 
 sleep 5
 
-curl -I http://localhost:${WEBPORT}${WEBPREFIX}/webclient/login/
+curl -f -I http://localhost:${WEBPORT}${WEBPREFIX}/webclient/login/
 
-curl -I http://localhost:4080${WEBPREFIX}/webclient/login/
+curl -f -I http://localhost:4080${WEBPREFIX}/webclient/login/


### PR DESCRIPTION
Previously curl would return exit code 0 with any http status code. This PR adds the `-f` flag to return a non-zero code if the web server returns an error. See for example https://travis-ci.org/ome/omeroweb-install/jobs/268129590 where there is a 502 gateway error but travis still passes:
```
+curl -I http://172.17.0.2:80/omero/webclient/login/
HTTP/1.1 502 Bad Gateway

Server: nginx/1.10.2

Date: Thu, 24 Aug 2017 20:45:13 GMT

Content-Type: text/html

Content-Length: 173

Connection: keep-alive

...

travis_time:end:137a78ed:start=1503607508093393159,finish=1503607523696360450,duration=15602967291
[0K
[32;1mThe command "./.travis/script.sh" exited with 0.[0m

Done. Your build exited with 0.
```

If this PR works it should cause travis to fail (since it was incorrectly passing in the past). This should then be remedied by https://github.com/ome/omeroweb-install/pull/21/