### PR TITLE
Remove when command

### DIFF
--- a/ansible/omeroweb-install.yml
+++ b/ansible/omeroweb-install.yml
@@ -61,7 +61,6 @@
         src: "{{ os }}/deps_ice{{ ice_version }}.sh.j2"
         dest: "{{ path }}/{{ prefix }}/deps_ice{{ ice_version }}.sh"
         mode: a+x
-      when: "{{ ice_version }}"
     - name: Generate {{ prefix }}/deps_web_session.sh
       template:
         src: "{{ os }}/deps_web_session.sh.j2"


### PR DESCRIPTION
This should remove warning 

```
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: {{ ice_version }}
```
Check one of the jobs and see in the log if the warning is still present