### PR TITLE
Turn osx off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,6 @@ matrix:
       dist: trusty
       env:
         - OS=ubuntu ICEVER=3.6 OMEROVER=latest DOCKER=true
-    - os: osx
-      osx_image: xcode7.3
-      env:
-        - OS=osx ICEVER=3.6 OMEROVER=latest WEBPORT=8080 WEBPREFIX=/omero
     # debian
     - os: linux
       dist: trusty


### PR DESCRIPTION
Discussed today
Turning osx off for now
since we do not recommend OSX as a production platform
and the current implementation does not work

This blocks the integration of https://github.com/ome/omeroweb-install/pull/24 
