### PR TITLE
install jinja2

### DIFF
--- a/ansible/templates/centos7/deps.sh.j2
+++ b/ansible/templates/centos7/deps.sh.j2
@@ -11,7 +11,7 @@ yum -y install epel-release
 
 yum -y install unzip
 
-yum -y install python-pip
+yum -y install python-{pip,jinja2}
 
 yum -y install nginx
 

--- a/ansible/templates/debian9/deps.sh.j2
+++ b/ansible/templates/debian9/deps.sh.j2
@@ -14,7 +14,7 @@ apt-get update
 
 apt-get -y install unzip
  
-apt-get -y install python-pip python-virtualenv
+apt-get -y install python-{pip,virtualenv,jinja2}
 
 # to be installed if recommended/suggested is false
 apt-get -y install virtualenv

--- a/ansible/templates/ubuntu1604/deps.sh.j2
+++ b/ansible/templates/ubuntu1604/deps.sh.j2
@@ -14,7 +14,7 @@ apt-get update
 
 apt-get -y install unzip
 
-apt-get -y install python-pip python-virtualenv
+apt-get -y install python-{pip,virtualenv,jinja2}
 
 # to be installed if recommended/suggested is false
 apt-get -y install virtualenv

--- a/ansible/templates/ubuntu1804/deps.sh.j2
+++ b/ansible/templates/ubuntu1804/deps.sh.j2
@@ -14,7 +14,7 @@ apt-get update
 
 apt-get -y install unzip
 
-apt-get -y install python-pip python-virtualenv
+apt-get -y install python-{pip,virtualenv,jinja2}
 
 # to be installed if recommended/suggested is false
 apt-get -y install virtualenv


### PR DESCRIPTION
install jinja2 using the package manager
The changes match what is currently installed using https://github.com/ome/omero-install
see https://trello.com/c/QaxIg0AH/156-jinja-warning

cc @joshmoore @mtbc 