### PR TITLE
centos: remove python-redis

### DIFF
--- a/ansible/templates/centos7/deps_web_session.sh.j2
+++ b/ansible/templates/centos7/deps_web_session.sh.j2
@@ -6,7 +6,7 @@
 set -e -u -x
 {% endif %}
 
-yum -y install redis python-redis
+yum -y install redis
 
 systemctl enable redis.service
 


### PR DESCRIPTION
This is a python 2 package