### PR TITLE
install ansible only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ome-ansible-molecule
+ansible

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible
+ansible==2.10.7


### PR DESCRIPTION
This PR removes the usage of ``ome-ansible-molecule`` since it is not required to test the build
Only ``ansible`` is installed.

As a side note the usage of ``ome-ansible-molecule`` leads to the following error
```
        File "/tmp/pip-install-b551f97d/anyconfig_560ed28b3d424ac6a5458cedee7f0be4/anyconfig/utils.py", line 385, in <module>
          _LIST_LIKE_TYPES = (collections.Iterable, collections.Sequence)
      AttributeError: module 'collections' has no attribute 'Iterable'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```
This is outside the scope of this PR but other repo might be affected cc @sbesson 

Check that the build is green. Note that GHA workflow is currently broken without the change