### PR TITLE
Initial commit for rockylinux9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [centos7, ubuntu1804, ubuntu2004, debian10]
-        websession: [true, false]
-        webprefix: ["", "/omero"]
+        os: [rockylinux9]
+        websession: [true]
+        webprefix: [""]
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ ansible/.DS_Store
 **/ubuntu2004-*/**
 **/debian10-*/**
 **/osx*/**
+**/rockylinux9*/**
 **/doc/**

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ ansible/.DS_Store
 **/ubuntu2004-*/**
 **/debian10-*/**
 **/osx*/**
-**/rockylinux9*/**
+**/rockylinux9-*/**
 **/doc/**

--- a/ansible/group_vars/rockylinux9-ice3.6
+++ b/ansible/group_vars/rockylinux9-ice3.6
@@ -4,7 +4,7 @@ path: "{{ playbook_dir }}"
 clean:
 os: rockylinux9
 ice_version: "3.6"
-python_version: "3.10"
+python_version: "3.9"
 
 doc: False
 doc_conf:

--- a/ansible/group_vars/rockylinux9-ice3.6
+++ b/ansible/group_vars/rockylinux9-ice3.6
@@ -1,0 +1,51 @@
+# INTERNAL CONFIG DON'T CHANGE
+
+path: "{{ playbook_dir }}"
+clean:
+os: rockylinux9
+ice_version: "3.6"
+python_version: "3.10"
+
+doc: False
+doc_conf:
+  note: ".. walkthroughs are generated using ansible, see \n.. https://github.com/ome/omeroweb-install\n"
+  header: "OMERO.web installation on Rocky Linux 9 and IcePy 3.6\n================================================\n"
+  link_install: "Please first read :doc:`../../server-rockylinux9-ice36`.\n"
+  os_full_name: Rocky Linux 9
+  prerequisites: "Installing prerequisites\n------------------------\n"
+  virtual_env: "Creating a virtual environment\n------------------------------\n"
+  web_install: "Installing OMERO.web\n--------------------\n"
+  webapps_install: "Installing OMERO.web apps\n-------------------------\n"
+  web_configuration: "Configuring OMERO.web\n---------------------\n"
+  gunicorn_configuration: "Configuring Gunicorn\n--------------------\n"
+  cors_configuration: "Setting up CORS\n---------------\n"
+  standalone_web: "Running OMERO.web\n-----------------\n"
+  nginx_configuration: "Configuring NGINX\n-----------------\n"
+  sel: "SELinux\n-------\n"
+  web_run: "Automatically running OMERO.web\n-------------------------------\n"
+  maintenance: "Maintaining OMERO.web\n---------------------\n"
+  troubleshoot: "Troubleshooting\n---------------\n"
+  gunicorn_configuration_advanced: "Configuring Gunicorn advanced options\n-------------------------------------\n"
+  sync_workers: "Experimental: Sync workers\n~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+  async_workers: "Experimental: Async workers\n~~~~~~~~~~~~~~~~~~~~~~~~~~~\n"
+
+default:
+  web_prefix:
+  web_port: 80
+  web_server_name: localhost
+
+omero_user: "omero-web"
+omero_user_home_dir: "/opt/omero/web"
+virtualenv_path: "{{ omero_user_home_dir }}/venv3"
+omero_user_web_dir: "{{ omero_user_home_dir }}/omero-web"
+
+selinux: True
+daemon: True
+
+# VARS
+
+web_session:
+
+web_prefix:
+web_port:
+web_server_name:

--- a/ansible/hosts/rockylinux9-ice3.6
+++ b/ansible/hosts/rockylinux9-ice3.6
@@ -1,0 +1,5 @@
+# Hosts can be part of multiple hostgroups, but note that vars will be
+# read for all groups that the host is a member of
+
+[rockylinux9-ice3.6]
+localhost ansible_connection=local

--- a/ansible/omeroweb-install.yml
+++ b/ansible/omeroweb-install.yml
@@ -111,7 +111,7 @@
       template:
         src: "{{ os }}/omero-web-systemd.service.j2"
         dest: "{{ path }}/{{ prefix }}/omero-web-systemd.service"
-      when: (os | regex_findall("centos"))
+      when: (os | regex_findall("centos")) or (os | regex_findall("rocky"))
     - name: Generate omero-web-init.d (ubuntu/debian)
       template:
         src: "{{ os }}/omero-web-init.d.j2"

--- a/ansible/templates/rockylinux9/daemon.sh.j2
+++ b/ansible/templates/rockylinux9/daemon.sh.j2
@@ -1,0 +1,33 @@
+{% if doc %}
+Copy the `systemd.service` file, then enable and start the service::
+{% else %}
+#!/bin/bash
+
+set -e -u -x
+{% endif %}
+
+{% if doc %}
+cp omero-web-systemd.service /etc/systemd/system/omero-web.service
+{% else %}
+cp `dirname $0`/omero-web-systemd.service /etc/systemd/system/omero-web.service
+{% endif %}
+
+{% if doc %}
+systemctl daemon-reload
+{% else %}
+if [ ! "${container:-}" = docker ]; then
+    systemctl daemon-reload
+fi
+{% endif %}
+
+systemctl enable omero-web.service
+
+{% if doc %}
+systemctl stop omero-web.service
+
+systemctl start omero-web.service
+{% else %}
+if [ ! "${container:-}" = docker ]; then
+    systemctl start omero-web.service
+fi
+{% endif %}

--- a/ansible/templates/rockylinux9/daemon.sh.j2
+++ b/ansible/templates/rockylinux9/daemon.sh.j2
@@ -15,7 +15,7 @@ cp `dirname $0`/omero-web-systemd.service /etc/systemd/system/omero-web.service
 {% if doc %}
 systemctl daemon-reload
 {% else %}
-if [ ! "${container:-}" = docker ]; then
+if [ ! -f /.dockerenv ]; then
     systemctl daemon-reload
 fi
 {% endif %}
@@ -27,7 +27,7 @@ systemctl stop omero-web.service
 
 systemctl start omero-web.service
 {% else %}
-if [ ! "${container:-}" = docker ]; then
+if [ ! -f /.dockerenv ]; then
     systemctl start omero-web.service
 fi
 {% endif %}

--- a/ansible/templates/rockylinux9/deps.sh.j2
+++ b/ansible/templates/rockylinux9/deps.sh.j2
@@ -1,0 +1,15 @@
+{% if doc %}
+Install dependencies::
+{% else %}
+#!/bin/bash
+
+set -e -u -x
+{% endif %}
+
+yum -y install epel-release
+
+yum -y install unzip
+
+yum -y install python3
+
+yum -y install nginx

--- a/ansible/templates/rockylinux9/deps_ice3.6.sh.j2
+++ b/ansible/templates/rockylinux9/deps_ice3.6.sh.j2
@@ -1,0 +1,11 @@
+{% if doc %}
+Install ZeroC IcePy {{ ice_version }}::
+{% else %}
+#!/bin/bash
+
+set -e -u -x
+
+# ZeroC Ice 3.6
+{% endif %}
+
+{{ virtualenv_path }}/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl

--- a/ansible/templates/rockylinux9/deps_ice3.6.sh.j2
+++ b/ansible/templates/rockylinux9/deps_ice3.6.sh.j2
@@ -8,4 +8,4 @@ set -e -u -x
 # ZeroC Ice 3.6
 {% endif %}
 
-{{ virtualenv_path }}/bin/pip install https://github.com/sbesson/zeroc-ice-py-rockylinux9-x86_64/releases/download/20230719/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl
+{{ virtualenv_path }}/bin/pip install https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl

--- a/ansible/templates/rockylinux9/deps_ice3.6.sh.j2
+++ b/ansible/templates/rockylinux9/deps_ice3.6.sh.j2
@@ -8,4 +8,4 @@ set -e -u -x
 # ZeroC Ice 3.6
 {% endif %}
 
-{{ virtualenv_path }}/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
+{{ virtualenv_path }}/bin/pip install https://github.com/sbesson/zeroc-ice-py-rockylinux9-x86_64/releases/download/20230719/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl

--- a/ansible/templates/rockylinux9/deps_web_session.sh.j2
+++ b/ansible/templates/rockylinux9/deps_web_session.sh.j2
@@ -1,0 +1,19 @@
+{% if doc %}
+*Optional*: if you wish to use the Redis cache, install Redis::
+{% else %}
+#!/bin/bash
+
+set -e -u -x
+{% endif %}
+
+yum -y install redis
+
+systemctl enable redis.service
+
+{% if doc %}
+systemctl start redis.service
+{% else %}
+if [ ! "${container:-}" = docker ]; then
+    systemctl start redis.service
+fi
+{% endif %}

--- a/ansible/templates/rockylinux9/deps_web_session.sh.j2
+++ b/ansible/templates/rockylinux9/deps_web_session.sh.j2
@@ -13,7 +13,7 @@ systemctl enable redis.service
 {% if doc %}
 systemctl start redis.service
 {% else %}
-if [ ! "${container:-}" = docker ]; then
+if [ ! -f /.dockerenv ]; then
     systemctl start redis.service
 fi
 {% endif %}

--- a/ansible/templates/rockylinux9/nginx.sh.j2
+++ b/ansible/templates/rockylinux9/nginx.sh.j2
@@ -1,0 +1,23 @@
+{% if doc %}
+Copy the generated configuration file into the NGINX configuration directory, disable the default configuration and start NGINX::
+{% else %}
+#!/bin/bash
+
+set -e -u -x
+{% endif %}
+
+sed -i.bak -re 's/( default_server.*)/; #\1/' /etc/nginx/nginx.conf
+if [ -f /etc/nginx/conf.d/default.conf ]; then
+    mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.disabled
+fi
+cp {{ omero_user_web_dir }}/nginx.conf.tmp /etc/nginx/conf.d/omeroweb.conf
+
+systemctl enable nginx
+
+{% if doc %}
+systemctl start nginx
+{% else %}
+if [ ! "${container:-}" = docker ]; then
+    systemctl start nginx
+fi
+{% endif %}

--- a/ansible/templates/rockylinux9/nginx.sh.j2
+++ b/ansible/templates/rockylinux9/nginx.sh.j2
@@ -17,7 +17,7 @@ systemctl enable nginx
 {% if doc %}
 systemctl start nginx
 {% else %}
-if [ ! "${container:-}" = docker ]; then
+if [ ! -f /.dockerenv ]; then
     systemctl start nginx
 fi
 {% endif %}

--- a/ansible/templates/rockylinux9/omero-web-systemd.service.j2
+++ b/ansible/templates/rockylinux9/omero-web-systemd.service.j2
@@ -1,0 +1,23 @@
+{% if doc %}
+Should you wish to run OMERO.web automatically, a `systemd.service` file could be created. See below an example file `omero-web-systemd.service`::
+
+{% endif %}
+[Unit]
+Description=OMERO.web
+# Not mandatory, NGINX may be running on a different server
+Requires=nginx.service
+After=network.service
+
+[Service]
+User={{ omero_user }}
+Type=forking
+PIDFile={{ omero_user_web_dir }}/var/django.pid
+Restart=no
+RestartSec=10
+Environment="PATH={{ virtualenv_path }}/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin"
+Environment="OMERODIR={{ omero_user_web_dir }}"
+ExecStart={{ virtualenv_path }}/bin/omero web start
+ExecStop={{ virtualenv_path }}/bin/omero web stop
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/rockylinux9/selinux.sh.j2
+++ b/ansible/templates/rockylinux9/selinux.sh.j2
@@ -1,0 +1,16 @@
+{% if doc %}
+If you are running a system with `SELinux enabled <https://wiki.centos.org/HowTos/SELinux>`_ and are unable to access OMERO.web you may need to adjust the security policy::
+{% else %}
+#!/bin/bash
+
+set -e -u -x
+{% endif %}
+
+if [ $(getenforce) != Disabled ]; then
+
+    yum -y install policycoreutils-python
+    setsebool -P httpd_read_user_content 1
+    setsebool -P httpd_enable_homedirs 1
+    semanage port -a -t http_port_t -p tcp 4080
+
+fi

--- a/test/Dockerfile_rockylinux9
+++ b/test/Dockerfile_rockylinux9
@@ -1,7 +1,7 @@
 # Dockerfile for testing the OMERO Rocky Linux installation instructions
 # Not intended for production use
 # Note to enable systemd this must be run with on a host with systemd
-FROM eniocarboni/docker-rockylinux-systemd:9
+FROM rockylinux:9
 LABEL author="ome-devel@lists.openmicroscopy.org.uk"
 
 # Remove the existing omero user

--- a/test/Dockerfile_rockylinux9
+++ b/test/Dockerfile_rockylinux9
@@ -1,0 +1,31 @@
+# Dockerfile for testing the OMERO Rocky Linux installation instructions
+# Not intended for production use
+# Note to enable systemd this must be run with on a host with systemd
+FROM eniocarboni/docker-rockylinux-systemd:9
+LABEL author="ome-devel@lists.openmicroscopy.org.uk"
+
+# Remove the existing omero user
+# RUN userdel -r omero && \
+# 	rm -f /etc/sudoers.d/omero && \
+# 	echo 'root:omero' | chpasswd
+
+ADD ./omeroweb-install-test.zip /tmp
+RUN yum -y install initscripts unzip
+RUN unzip /tmp/omeroweb-install-test.zip -d /tmp
+
+# This is so that scripts can detect whether they're in docker
+RUN echo 'export container=docker' > /etc/profile.d/docker.sh
+
+ARG ICEVER=3.6
+ARG WEBPORT=80
+ARG WEBPREFIX
+ARG WEBSESSION
+ARG WEBSERVER_CONF
+ARG WEBSERVER_NAME
+
+RUN ICEVER=$ICEVER \
+    WEBPORT=$WEBPORT WEBPREFIX=$WEBPREFIX WEBSESSION=$WEBSESSION \
+    WEBSERVER_CONF=$WEBSERVER_CONF WEBSERVER_NAME=$WEBSERVER_NAME \
+    /tmp/omeroweb-install-test/omeroweb-install-rockylinux9-ice${ICEVER}
+
+EXPOSE 22 80

--- a/test/Dockerfile_rockylinux9
+++ b/test/Dockerfile_rockylinux9
@@ -4,17 +4,14 @@
 FROM rockylinux:9
 LABEL author="ome-devel@lists.openmicroscopy.org.uk"
 
-# Remove the existing omero user
-# RUN userdel -r omero && \
-# 	rm -f /etc/sudoers.d/omero && \
-# 	echo 'root:omero' | chpasswd
+RUN touch /.dockerenv
 
 ADD ./omeroweb-install-test.zip /tmp
 RUN yum -y install initscripts unzip
 RUN unzip /tmp/omeroweb-install-test.zip -d /tmp
 
 # This is so that scripts can detect whether they're in docker
-RUN echo 'export container=docker' > /etc/profile.d/docker.sh
+RUN touch /.dockerenv
 
 ARG ICEVER=3.6
 ARG WEBPORT=80


### PR DESCRIPTION
First stab at adding rockylinux9 support.

Using https://hub.docker.com/r/eniocarboni/docker-rockylinux-systemd

Testing locally...

```
$ OS=rockylinux9 ICEVER=3.6 WEBPREFIX=/omero .travis/before_install.sh
# OK....

$ OS=rockylinux9 ICEVER=3.6 WEBPREFIX=/omero DOCKER=true TRAVIS_OS_NAME=linux .travis/install.sh
...
#10 30.21 + bash /tmp/omeroweb-install-test/rockylinux9-ice3.6/virtualenv.sh
#10 30.21 + '[' '' = 3.6 ']'
#10 30.21 + python3 -mvenv /opt/omero/web/venv3
#10 31.76 + bash /tmp/omeroweb-install-test/rockylinux9-ice3.6/deps_ice3.6.sh
#10 31.76 + /opt/omero/web/venv3/bin/pip install https://github.com/ome/zeroc-ice-py-centos7/releases/download/0.2.1/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl
#10 31.91 ERROR: zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl is not a supported wheel on this platform.
```