### PR TITLE
Replace lsb_release call with parsing /etc/os-release

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -12,7 +12,7 @@ if [ ! -z ${TRAVIS:-} ] ; then
         if ${DOCKER:-false} ; then
             echo "Installing Docker"
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-            sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+            sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(grep -Po 'VERSION_CODENAME=\K.*' /etc/os-release) stable"
             sudo apt-get update
             sudo apt-get -y install docker-ce
         fi


### PR DESCRIPTION
The lsb project is in an abonded state and some distros have already dropped support for the `lsb_release` command (notably RHEL 9 and clones). It can be suspected that more distros (including Ubuntu) might drop support for it. Therefore: Replace lsb_release call with parsing /etc/os-release which is provided with all major distros.
This change is in line with removing `lsb_release` installations in the OME Ansible roles (https://github.com/ome/ansible-role-basedeps/pull/12).